### PR TITLE
Ensure types match format specifiers

### DIFF
--- a/Glk/glk.c
+++ b/Glk/glk.c
@@ -4602,7 +4602,9 @@ gln_command_print_version_number (glui32 version)
   char buffer[64];
 
   sprintf (buffer, "%lu.%lu.%lu",
-           version >> 16, (version >> 8) & 0xff, version & 0xff);
+          (unsigned long) version >> 16,
+          (unsigned long) (version >> 8) & 0xff,
+          (unsigned long) version & 0xff);
   gln_normal_string (buffer);
 }
 


### PR DESCRIPTION
version is glui32, which isn't necessarily unsigned long.