### PR TITLE
Add .tzx and .l9 extensions to file chooser

### DIFF
--- a/Gtk/main.c
+++ b/Gtk/main.c
@@ -237,6 +237,8 @@ void start_new_game (gchar *game_filename, gchar *graphics_filename)
     const gchar *filters[] =
 	{
 	    "Level 9 data files (*.dat)", "*.dat",
+	    "Level 9 Gargoyle files (*.l9)", "*.l9",
+	    "Spectrum tapes (*.tzx)", "*.tzx",
 	    "Spectrum snapshots (*.sna)", "*.sna",
 	    NULL
 	};

--- a/Gtk/util.c
+++ b/Gtk/util.c
@@ -122,6 +122,15 @@ gchar *file_selector (gboolean save, gchar *name, const gchar *filters[],
 	GtkFileFilter *filter;
 	int i;
 
+	if (!save) {
+	    filter = gtk_file_filter_new ();
+	    gtk_file_filter_set_name (filter, "All supported files");
+	    for (i = 0; filters[i]; i += 2) {
+		gtk_file_filter_add_pattern (filter, filters[i + 1]);
+	    }
+	    gtk_file_chooser_add_filter (GTK_FILE_CHOOSER(dialog), filter);
+	}
+
 	for (i = 0; filters[i]; i += 2)
 	{
 	    filter = gtk_file_filter_new ();

--- a/Gtk/util.c
+++ b/Gtk/util.c
@@ -40,6 +40,8 @@ L9BOOL os_get_game_file(char *NewName, int Size)
     const gchar *filters[] =
 	{
 	    "Level 9 data files (*.dat)", "*.dat",
+	    "Level 9 Gargoyle files (*.l9)", "*.l9",
+	    "Spectrum tapes (*.tzx)", "*.tzx",
 	    "Spectrum snapshots (*.sna)", "*.sna",
 	    NULL
 	};

--- a/Win/Lev9win.cpp
+++ b/Win/Lev9win.cpp
@@ -542,7 +542,7 @@ void Resize()
   InvalidateRect(hWndMain,NULL,TRUE);
 }
 
-const char Filters[]="Level 9 Game Files (*.dat)\0*.dat\0Level 9 Gargoyle Files (*.l9)\0*.l9\0Spectrum Tapes (*.tzx)\0*.tzx\0Spectrum Snapshots (*.sna)\0*.sna\0All Files (*.*)\0*.*\0\0";
+const char Filters[]="All Supported Files (*.dat;*.l9;*.tzx;*.sna)\0*.dat;*.l9;*.tzx;*.sna\0Level 9 Game Files (*.dat)\0*.dat\0Level 9 Gargoyle Files (*.l9)\0*.l9\0Spectrum Tapes (*.tzx)\0*.tzx\0Spectrum Snapshots (*.sna)\0*.sna\0All Files (*.*)\0*.*\0\0";
 int FiltIndex;
 const char GameFilters[]="Saved game file (*.sav)\0*.sav\0All Files (*.*)\0*.*\0\0";
 FName LastGameFile;
@@ -1499,7 +1499,7 @@ void MyApp::SetDefs()
 {
   // Set application default settings here
   LastFile="";
-  FiltIndex=0;
+  FiltIndex=1;
   LastGameFile="";
   GameFiltIndex=0;
   LastScriptFile="";

--- a/Win/Lev9win.cpp
+++ b/Win/Lev9win.cpp
@@ -542,7 +542,7 @@ void Resize()
   InvalidateRect(hWndMain,NULL,TRUE);
 }
 
-const char Filters[]="Level 9 Game Files (*.dat)\0*.dat\0Spectrum Snapshots (*.sna)\0*.sna\0All Files (*.*)\0*.*\0\0";
+const char Filters[]="Level 9 Game Files (*.dat)\0*.dat\0Level 9 Gargoyle Files (*.l9)\0*.l9\0Spectrum Tapes (*.tzx)\0*.tzx\0Spectrum Snapshots (*.sna)\0*.sna\0All Files (*.*)\0*.*\0\0";
 int FiltIndex;
 const char GameFilters[]="Saved game file (*.sav)\0*.sav\0All Files (*.*)\0*.*\0\0";
 FName LastGameFile;


### PR DESCRIPTION
This adds .tzx and .l9 as valid extensions in Windows and Gtk ports.

.tzx support appears undocumented, but it works fine, tested with several tapes.

.l9 is just a fancy extension Gargoyle uses for identifying Level 9 games, probably because .dat is so ubiquitous. it has [propagated by now](https://extension.nirsoft.net/l9), let's add it for convenience.