### PR TITLE
GTK: QoL update

### DIFF
--- a/Gtk/NEWS
+++ b/Gtk/NEWS
@@ -1,3 +1,53 @@
+2025-03-XX - 2.1 (The "Diamonds for eyes" release.)
+
+Bugfixes
+
+- Fixed a crash when trying to open a new game file while waiting for
+  timeout or keypress to skip picture.
+
+- An issue with system locales using commas for decimals would prevent
+  loading floating-point numbers from the configuration file, so all
+  values were being rounded to the nearest integer. They're now parsed
+  correctly regardless of whether decimal points or commas are being
+  used.
+
+- Set a minimum fifty-pixel gap between the movable viewport divider and
+  the window edge to prevent viewports from unexpectedly having zero
+  width or height due to wonky window resizing mechanics.
+
+- Fixed Lancelot hanging up on moving back from part two to part one
+  when using files with .l9 and .l2 extensions.
+
+Other changes
+
+- Improved font rendering quality with antialiasing, light hinting
+  and subpixel rendering.
+
+- Text margins and line spacing have been adjusted for readability,
+  and both are now configurable.
+
+- There's now an option to dynamically scale graphics to fit the
+  viewport size, and this will be the default for new configurations.
+
+- The graphics pane can now be positioned to the left and right sides,
+  above and below the text box, or disabled altogether for a text-only
+  mode. This replaces the horizontal split option.
+
+- Reworked the preferences dialog, so it now features live preview,
+  "reset to default" buttons where appropriate, and keyboard mnemonics
+  for all options to enhance accessibility.
+
+- My hand slipped one too many times, so there's now a confirmation
+  dialog when quitting.
+
+- The configuration file has migrated from user's home directory and now
+  lives in the standard XDG .config directory. If the old file is found,
+  it will move over to its new place automatically.
+
+- Conflated "Scale image to constant height" and "Scale factor" options
+  into a single entry, as they were both doing basically the same thing
+  using different calculations.
+
 2025-02-XX - 2.0 (The "Two birds" release.)
 
 GTK 3 port.

--- a/Gtk/config.c
+++ b/Gtk/config.c
@@ -43,19 +43,20 @@ Configuration Config =
     2 * MIN_WINDOW_HEIGHT,  /* window height                        */
     150,                    /* partition                            */
     NULL,                   /* text font                            */
+    20,                     /* text margin                          */
+    1.0,                    /* text leading                         */
     NULL,                   /* text foreground colour               */
     NULL,                   /* text background colour               */
-    FALSE,                  /* scale image to constant height?      */
-    1.0,                    /* image scaling                        */
-    300,                    /* constant image height                */
+    NULL,                   /* graphics background colour           */
     GDK_INTERP_BILINEAR,    /* interpolation mode for image scaling */
+    0,                      /* graphics position                    */
+    TRUE,                   /* fit to window                        */
+    1.0,                    /* image scaling                        */
     1.0,                    /* red gamma                            */
     1.0,                    /* green gamma                          */
     1.0,                    /* blue gamma                           */
-    NULL,                   /* graphics background colour           */
     TRUE,                   /* animate images                       */
-    10,                     /* animation speed                      */
-    FALSE                   /* horizontal split                     */
+    10                      /* animation speed                      */
 };
 
 /* ------------------------------------------------------------------------- *
@@ -64,12 +65,18 @@ Configuration Config =
 
 static gchar *get_config_filename ()
 {
-    /*
-     * GLIB 2.6 introduced a g_get_user_config_dir() function. Perhaps we
-     * should use that instead, but I don't want want to write the migration
-     * code for it.
-     */
-    return g_build_filename (g_get_home_dir (), ".gtklevel9", NULL);
+    gchar *new_path = g_build_filename (
+	g_get_user_config_dir (), "gtklevel9", NULL);
+    if (!g_file_test (new_path, G_FILE_TEST_EXISTS)) {
+	gchar *old_path = g_build_filename (
+	    g_get_home_dir (), ".gtklevel9", NULL);
+	if (g_file_test (old_path, G_FILE_TEST_EXISTS)) {
+	    g_mkdir_with_parents (g_get_user_config_dir (), 0755);
+	    g_rename (old_path, new_path);
+	}
+	g_free (old_path);
+    }
+    return new_path;
 }
 
 /* ------------------------------------------------------------------------- *
@@ -88,7 +95,7 @@ void write_config_file ()
      * setting is up to date.
      */
     Config.window_split = gtk_paned_get_position (GTK_PANED (Gui.partition));
-    
+
     filename = get_config_filename ();
     file = g_io_channel_new_file (filename, "w", &error);
     g_free (filename);
@@ -106,25 +113,26 @@ void write_config_file ()
 	    "      <width>%d</width>\n"
 	    "      <height>%d</height>\n"
 	    "      <split>%d</split>\n"
-	    "      <horizontal_split>%s</horizontal_split>\n"
 	    "    </main_window>\n"
 	    "  </layout>\n\n"
 	    
 	    "  <text>\n"
 	    "    <font>%s</font>\n"
+	    "    <margin>%d</margin>\n"
+	    "    <leading>%.2f</leading>\n"
 	    "    <foreground>%s</foreground>\n"
 	    "    <background>%s</background>\n"
 	    "  </text>\n\n"
 	    
 	    "  <graphics>\n"
-	    "    <constant_height>%s</constant_height>\n"
-	    "    <scale>%f</scale>\n"
-	    "    <height>%d</height>\n"
+	    "    <graphics_position>%d</graphics_position>\n"
+	    "    <fit_to_window>%s</fit_to_window>\n"
+	    "    <scale>%.2f</scale>\n"
 	    "    <filter>%d</filter>\n"
 	    "    <gamma>\n"
-	    "      <red>%f</red>\n"
-	    "      <green>%f</green>\n"
-	    "      <blue>%f</blue>\n"
+	    "      <red>%.2f</red>\n"
+	    "      <green>%.2f</green>\n"
+	    "      <blue>%.2f</blue>\n"
 	    "    </gamma>\n"
 	    "    <background>%s</background>\n"
 	    "    <animate>%s</animate>\n"
@@ -136,13 +144,14 @@ void write_config_file ()
 	    Config.window_width,
 	    Config.window_height,
 	    Config.window_split,
-	    Config.horizontal_split ? "TRUE" : "FALSE",
 	    Config.text_font ? Config.text_font : "",
+	    Config.text_margin,
+	    Config.text_leading,
 	    Config.text_fg ? Config.text_fg : "",
 	    Config.text_bg ? Config.text_bg : "",
-	    Config.image_constant_height ? "TRUE" : "FALSE",
+	    Config.graphics_position,
+	    Config.fit_to_window ? "TRUE" : "FALSE",
 	    Config.image_scale,
-	    Config.image_height,
 	    Config.image_filter,
 	    Config.red_gamma,
 	    Config.green_gamma,
@@ -237,7 +246,7 @@ static void config_parse_start_element (GMarkupParseContext *context,
 		}
 	    }
 	    break;
-	    
+
 	case CONFIG_PARSE_CONFIGURATION:
 	    if (strcmp (element_name, "layout") == 0)
 		parser_state = CONFIG_PARSE_LAYOUT;
@@ -259,8 +268,6 @@ static void config_parse_start_element (GMarkupParseContext *context,
 		parserInt = &(Config.window_height);
 	    else if (strcmp (element_name, "split") == 0)
 		parserInt = &(Config.window_split);
-	    else if (strcmp (element_name, "horizontal_split") == 0)
-		parserBool = &(Config.horizontal_split);
 	    break;
 
 	case CONFIG_PARSE_TEXT:
@@ -270,15 +277,19 @@ static void config_parse_start_element (GMarkupParseContext *context,
 		parserChar = &(Config.text_bg);
 	    else if (strcmp (element_name, "foreground") == 0)
 		parserChar = &(Config.text_fg);
+	    else if (strcmp (element_name, "margin") == 0)
+		parserInt = &(Config.text_margin);
+	    else if (strcmp (element_name, "leading") == 0)
+		parserFloat = &(Config.text_leading);
 	    break;
 
 	case CONFIG_PARSE_GRAPHICS:
-	    if (strcmp (element_name, "constant_height") == 0)
-		parserBool = &(Config.image_constant_height);
+	    if (strcmp (element_name, "graphics_position") == 0)
+		parserInt = &(Config.graphics_position);
+	    else if (strcmp (element_name, "fit_to_window") == 0)
+		parserBool = &(Config.fit_to_window);
 	    else if (strcmp (element_name, "scale") == 0)
 		parserFloat = &(Config.image_scale);
-	    else if (strcmp (element_name, "height") == 0)
-		parserInt = &(Config.image_height);
 	    else if (strcmp (element_name, "filter") == 0)
 		parserInt = &(Config.image_filter);
 	    else if (strcmp (element_name, "gamma") == 0)
@@ -313,7 +324,7 @@ static void config_parse_end_element (GMarkupParseContext *context,
 				      GError **error)
 {
     config_parse_reset ();
-    
+
     switch (parser_state)
     {
 	case CONFIG_PARSE_CONFIGURATION:
@@ -363,8 +374,15 @@ static void config_parse_text (GMarkupParseContext *context,
 	*parserBool = (strcmp (text, "TRUE") == 0) ? TRUE : FALSE;
     else if (parserInt)
 	*parserInt = (gint) g_ascii_strtod (text, NULL);
-    else if (parserFloat)
-	*parserFloat = g_ascii_strtod (text, NULL);
+    else if (parserFloat) {
+	gchar *text_copy = g_strdup (text);
+	gchar *p;
+	for (p = text_copy; *p; p++) {
+	    if (*p == ',') *p = '.';
+	}
+	*parserFloat = g_ascii_strtod (text_copy, NULL);
+	g_free (text_copy);
+    }
     else if (parserChar)
     {
 	if (*parserChar)
@@ -429,50 +447,107 @@ void read_config_file ()
  * ------------------------------------------------------------------------- */
 
 static void toggle_sensitivity (GtkToggleButton *toggle_button,
-				gpointer user_data)
+    gpointer user_data)
 {
-    if (gtk_toggle_button_get_active (toggle_button))
-	gtk_widget_set_sensitive (GTK_WIDGET (user_data), TRUE);
-    else
-	gtk_widget_set_sensitive (GTK_WIDGET (user_data), FALSE);
+    GtkWidget *widget = GTK_WIDGET (user_data);
+    gtk_widget_set_sensitive (
+	widget, gtk_toggle_button_get_active (toggle_button));
+}
+
+static void reset_font (GtkWidget *button, GtkWidget *font_button)
+{
+    GtkSettings *settings = gtk_settings_get_default ();
+    gchar *font_name;
+    g_object_get (settings, "gtk-font-name", &font_name, NULL);
+    gtk_font_chooser_set_font (GTK_FONT_CHOOSER (font_button), font_name);
+    g_free (font_name);
+    Config.text_font = NULL;
+    g_signal_emit_by_name (font_button, "font-set");
+    text_refresh ();
 }
 
 static GtkWidget *add_font_button (GtkWidget *tab, gchar *text, gchar *title)
 {
     GtkWidget *label;
     GtkWidget *font_button;
+    GtkWidget *box;
+    GtkWidget *reset;
 
-    label = gtk_label_new (text);
+    box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
+    gtk_box_pack_start (GTK_BOX (tab), box, TRUE, TRUE, 0);
+
+    label = gtk_label_new_with_mnemonic ("_Text font:");
     gtk_label_set_xalign (GTK_LABEL (label), 0.0);
     gtk_label_set_yalign (GTK_LABEL (label), 0.5);
-    gtk_box_pack_start (GTK_BOX (tab), label, TRUE, TRUE, 0);
+    gtk_widget_set_size_request (label, 120, -1);
+    gtk_box_pack_start (GTK_BOX (box), label, FALSE, FALSE, 0);
 
     font_button = gtk_font_button_new ();
     gtk_font_button_set_use_font (GTK_FONT_BUTTON (font_button), TRUE);
     gtk_font_button_set_use_size (GTK_FONT_BUTTON (font_button), TRUE);
     gtk_font_button_set_title (GTK_FONT_BUTTON (font_button), title);
-    gtk_box_pack_start (GTK_BOX (tab), font_button, TRUE, TRUE, 0);
+    gtk_box_pack_start (GTK_BOX (box), font_button, TRUE, TRUE, 0);
+    gtk_label_set_mnemonic_widget (GTK_LABEL (label), font_button);
+
+    reset = gtk_button_new_from_icon_name ("view-refresh", GTK_ICON_SIZE_BUTTON);
+    gtk_style_context_add_class (gtk_widget_get_style_context (reset), "flat");
+    g_signal_connect (reset, "clicked", G_CALLBACK (reset_font), font_button);
+    gtk_box_pack_start (GTK_BOX (box), reset, FALSE, FALSE, 0);
 
     return font_button;
 }
 
-static GtkWidget *add_scale (GtkWidget *tab, gchar *text, gdouble min,
-			     gdouble max, gdouble step, gdouble value)
+static void reset_value (GtkWidget *button, GtkWidget *widget)
 {
-    GtkWidget *scale;
-    GtkWidget *label;
+    gdouble *default_value = g_object_get_data (
+	G_OBJECT (button), "default-value");
+    if (GTK_IS_SPIN_BUTTON (widget))
+	gtk_spin_button_set_value (GTK_SPIN_BUTTON (widget), *default_value);
+    else
+	gtk_range_set_value (GTK_RANGE (widget), *default_value);
+}
 
-    label = gtk_label_new (text);
+static GtkWidget *add_reset_button (GtkWidget *widget, gdouble default_value)
+{
+    GtkWidget *button = gtk_button_new_from_icon_name (
+	"view-refresh", GTK_ICON_SIZE_BUTTON);
+    gtk_style_context_add_class (
+	gtk_widget_get_style_context (button), "flat");
+    gdouble *value = g_new (gdouble, 1);
+    *value = default_value;
+    g_object_set_data_full (G_OBJECT (button), "default-value", value, g_free);
+    g_signal_connect (button, "clicked", G_CALLBACK (reset_value), widget);
+    return button;
+}
+
+static GtkWidget *add_scale (GtkWidget *tab, gchar *text, gdouble min,
+			   gdouble max, gdouble step, gdouble value,
+			   gint digits, gdouble reset_value)
+{
+    GtkWidget *box;
+    GtkWidget *label;
+    GtkWidget *scale;
+    GtkWidget *reset;
+
+    box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
+    gtk_box_pack_start (GTK_BOX (tab), box, TRUE, TRUE, 0);
+
+    label = gtk_label_new_with_mnemonic (text);
     gtk_label_set_xalign (GTK_LABEL (label), 0.0);
     gtk_label_set_yalign (GTK_LABEL (label), 0.5);
-    gtk_box_pack_start (GTK_BOX (tab), label, TRUE, TRUE, 0);
-    
+    gtk_widget_set_size_request (label, 120, -1);
+    gtk_box_pack_start (GTK_BOX (box), label, FALSE, FALSE, 0);
+
     scale = gtk_scale_new_with_range (GTK_ORIENTATION_HORIZONTAL,
 	min, max, step);
-    gtk_scale_set_digits (GTK_SCALE (scale), 2);
+    gtk_scale_set_digits (GTK_SCALE (scale), digits);
     gtk_scale_set_value_pos (GTK_SCALE (scale), GTK_POS_RIGHT);
     gtk_range_set_value (GTK_RANGE (scale), value);
-    gtk_box_pack_start (GTK_BOX (tab), scale, TRUE, TRUE, 0);
+    gtk_box_pack_start (GTK_BOX (box), scale, TRUE, TRUE, 0);
+    gtk_label_set_mnemonic_widget (GTK_LABEL (label), scale);
+
+    reset = add_reset_button (scale, reset_value);
+    gtk_box_pack_start (GTK_BOX (box), reset, FALSE, FALSE, 0);
 
     return scale;
 }
@@ -483,22 +558,12 @@ typedef struct
     GtkWidget *button;
 } ColourSetting;
 
-static void update_colour_setting (gchar **colour, ColourSetting *s)
-{
-    g_free (*colour);
+ColourSetting *text_fg;
+ColourSetting *text_bg;
+ColourSetting *graphics_bg;
 
-    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (s->checkbox)))
-    {
-	GdkRGBA rgba;
-
-	gtk_color_chooser_get_rgba (GTK_COLOR_CHOOSER (s->button), &rgba);
-	*colour = g_strdup_printf ("#%02X%02X%02X",
-				   (int) (rgba.red * 255),
-				   (int) (rgba.green * 255),
-				   (int) (rgba.blue * 255));
-    } else
-	*colour = NULL;
-}
+static void color_checkbox_changed (
+    GtkToggleButton *toggle_button, gpointer user_data);
 
 static ColourSetting *add_colour_setting (GtkWidget *tab, gchar *text,
 					  gchar *title, gchar *colour_name)
@@ -508,12 +573,21 @@ static ColourSetting *add_colour_setting (GtkWidget *tab, gchar *text,
 
     s = g_new (ColourSetting, 1);
 
-    s->checkbox = gtk_check_button_new_with_label (text);
+    s->checkbox = gtk_check_button_new_with_mnemonic (text);
     gtk_box_pack_start (GTK_BOX (tab), s->checkbox, TRUE, TRUE, 0);
 
     s->button = gtk_color_button_new ();
     gtk_box_pack_start (GTK_BOX (tab), s->button, TRUE, TRUE, 0);
     gtk_color_button_set_title (GTK_COLOR_BUTTON (s->button), title);
+
+    if (g_strcmp0 (text, "Override text _foreground colour") == 0) {
+	gdk_rgba_parse (&rgba, "#000000");
+    } else if (g_strcmp0 (text, "Override text _background colour") == 0) {
+	gdk_rgba_parse (&rgba, "#FFFFFF");
+    } else {
+	gdk_rgba_parse (&rgba, "#F6F5F4");
+    }
+    gtk_color_chooser_set_rgba (GTK_COLOR_CHOOSER(s->button), &rgba);
 
     if (colour_name && gdk_rgba_parse (&rgba, colour_name))
     {
@@ -522,57 +596,41 @@ static ColourSetting *add_colour_setting (GtkWidget *tab, gchar *text,
     } else
 	gtk_widget_set_sensitive (GTK_WIDGET (s->button), FALSE);
 
-    g_signal_connect (
-	G_OBJECT (s->checkbox), "toggled", G_CALLBACK (toggle_sensitivity),
-	s->button);
+    g_signal_connect (G_OBJECT (s->checkbox), "toggled",
+	G_CALLBACK (toggle_sensitivity), s->button);
+    g_signal_connect (G_OBJECT (s->checkbox), "toggled",
+	G_CALLBACK (color_checkbox_changed), s);
 
     return s;
 }
 
-static gulong hSigScaleChanged = 0;
-
-static GtkWidget *image_scale_label;
-static GtkWidget *image_scale;
-
-static gint tmp_image_height;
-static gfloat tmp_image_scale;
-
-static void toggle_constant_height (GtkToggleButton *toggle_button,
-				    gpointer user_data)
+static void update_colour_setting (gchar **colour, ColourSetting *s)
 {
-    /*
-     * Apparently changing the image scale the way we do below will cause
-     * the "value_changed" signal to be emitted, which will screw things up
-     * quite badly. So we block that signal temporarily.
-     */
-    
-    g_signal_handler_block (G_OBJECT (image_scale), hSigScaleChanged);
-    
-    if (gtk_toggle_button_get_active (toggle_button))
-    {
-	gtk_label_set_text (GTK_LABEL (image_scale_label), "Image height:");
-	gtk_scale_set_digits (GTK_SCALE (image_scale), 0);
-	gtk_range_set_range (GTK_RANGE (image_scale), 50, 1000);
-	gtk_range_set_increments (GTK_RANGE (image_scale), 1.0, 50.0);
-	gtk_range_set_value (GTK_RANGE (image_scale), tmp_image_height);
-    } else
-    {
-	gtk_label_set_text (GTK_LABEL (image_scale_label), "Scale factor:");
-	gtk_scale_set_digits (GTK_SCALE (image_scale), 2);
-	gtk_range_set_range (GTK_RANGE (image_scale), 0.1, 5.0);
-	gtk_range_set_increments (GTK_RANGE (image_scale), 0.01, 0.1);
-	gtk_range_set_value (GTK_RANGE (image_scale), tmp_image_scale);
+    if (*colour) {
+	g_free (*colour);
+	*colour = NULL;
     }
 
-    g_signal_handler_unblock (G_OBJECT (image_scale), hSigScaleChanged);
+    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (s->checkbox)))
+    {
+	GdkRGBA rgba;
+	gtk_color_chooser_get_rgba (GTK_COLOR_CHOOSER (s->button), &rgba);
+	*colour = g_strdup_printf ("#%02X%02X%02X",
+			       (int) (rgba.red * 255),
+			       (int) (rgba.green * 255),
+			       (int) (rgba.blue * 255));
+    }
 }
 
-static void change_image_scale (GtkRange *range, gpointer user_data)
+static GtkWidget *image_scale;
+
+static void on_scale_combo_changed (GtkComboBox *combo, gpointer user_data)
 {
-    if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (user_data)))
-	tmp_image_height = (gint) gtk_range_get_value (range);
-    else
-	tmp_image_scale = gtk_range_get_value (range);
+    GtkWidget *scale_box = GTK_WIDGET (user_data);
+    int active = gtk_combo_box_get_active (combo);
+    gtk_widget_set_sensitive (scale_box, active == 1);
+    Config.fit_to_window = (active == 0);
+    graphics_refresh ();
 }
 
 typedef struct
@@ -586,10 +644,10 @@ static const ComboBoxItem imageFilters[] = {
      * In reality, the value and index into this array are probably the same.
      * But I don't want to make that assumption.
      */
-    { "Nearest neighbor", GDK_INTERP_NEAREST  },
-    { "Tiles",            GDK_INTERP_TILES    },
-    { "Bilinear",         GDK_INTERP_BILINEAR },
-    { "Hyperbolic",       GDK_INTERP_HYPER    }
+    { "Nearest neighbour", GDK_INTERP_NEAREST  },
+    { "Tiles",             GDK_INTERP_TILES    },
+    { "Bilinear",          GDK_INTERP_BILINEAR },
+    { "Hyperbolic",        GDK_INTERP_HYPER    }
 };
 
 static int get_interp_type_index (GdkInterpType interp_type)
@@ -603,27 +661,173 @@ static int get_interp_type_index (GdkInterpType interp_type)
     return -1;
 }
 
+static GtkWidget *add_combo_box (GtkWidget *tab, gchar *text,
+				const gchar **items, gint n_items,
+				gint active)
+{
+    GtkWidget *box;
+    GtkWidget *label;
+    GtkWidget *combo;
+    gint i;
+
+    box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
+    gtk_box_pack_start (GTK_BOX (tab), box, TRUE, TRUE, 0);
+
+    label = gtk_label_new_with_mnemonic (text);
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+    gtk_label_set_yalign (GTK_LABEL (label), 0.5);
+    gtk_widget_set_size_request (label, 120, -1);
+    gtk_box_pack_start (GTK_BOX (box), label, FALSE, FALSE, 0);
+
+    combo = gtk_combo_box_text_new ();
+    for (i = 0; i < n_items; i++)
+	gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (combo), items[i]);
+    gtk_combo_box_set_active (GTK_COMBO_BOX (combo), active);
+    gtk_box_pack_start (GTK_BOX (box), combo, TRUE, TRUE, 0);
+    gtk_label_set_mnemonic_widget (GTK_LABEL (label), combo);
+
+    return combo;
+}
+
+static gchar *format_animation_speed (
+    GtkScale *scale, gdouble value, gpointer user_data)
+{
+    return g_strdup_printf ("%.0f   ", value);
+}
+
+static void scale_changed (GtkRange *range, gpointer user_data)
+{
+    if (user_data == &Config.animation_speed) {
+	Config.animation_speed = (gint) gtk_range_get_value(range);
+    } else {
+	gdouble *target = (gdouble *)user_data;
+	*target = gtk_range_get_value(range);
+    }
+    graphics_refresh ();
+}
+
+static void spin_changed_int (GtkSpinButton *spin, gpointer user_data)
+{
+    gint *target = (gint *) user_data;
+    if (GTK_IS_SPIN_BUTTON (spin)) {
+	*target = gtk_spin_button_get_value_as_int (spin);
+	text_refresh ();
+    }
+}
+
+static void spin_changed_float (GtkSpinButton *spin, gpointer user_data)
+{
+    gdouble *target = (gdouble *) user_data;
+    if (GTK_IS_SPIN_BUTTON (spin)) {
+	*target = gtk_spin_button_get_value (spin);
+	text_refresh ();
+    }
+}
+
+static void font_changed (GtkFontButton *button, gpointer user_data)
+{
+    const gchar *new_font =
+	gtk_font_chooser_get_font (GTK_FONT_CHOOSER (button));
+    if (new_font && g_utf8_validate (new_font, -1, NULL)) {
+	gchar *temp = g_strdup (new_font);
+	if (Config.text_font)
+	    g_free (Config.text_font);
+	Config.text_font = temp;
+	text_refresh ();
+    }
+}
+
+static void color_changed (GtkColorButton *button, gpointer user_data)
+{
+    gchar **target = (gchar **) user_data;
+    GdkRGBA rgba;
+    gtk_color_chooser_get_rgba (GTK_COLOR_CHOOSER (button), &rgba);
+    if (*target)
+	g_free (*target);
+    *target = g_strdup_printf ("#%02X%02X%02X",
+			    (int) (rgba.red * 255),
+			    (int) (rgba.green * 255),
+			    (int) (rgba.blue * 255));
+    if (target == &Config.graphics_bg)
+	graphics_refresh ();
+    else
+	text_refresh ();
+}
+
+static void on_filter_changed(GtkComboBox *combo, gpointer user_data)
+{
+    int filter_idx = gtk_combo_box_get_active(combo);
+    if (filter_idx != -1)
+	Config.image_filter = imageFilters[filter_idx].interp_type;
+    else
+	Config.image_filter = GDK_INTERP_BILINEAR;
+    graphics_refresh ();
+}
+
+static void on_position_changed (GtkComboBox *combo, gpointer user_data)
+{
+    Config.graphics_position = gtk_combo_box_get_active (combo);
+    gui_refresh();
+    graphics_refresh();
+}
+
+static void toggle_changed (GtkToggleButton *toggle_button, gpointer user_data)
+{
+    gboolean *target = (gboolean *) user_data;
+    *target = gtk_toggle_button_get_active (toggle_button);
+    graphics_run ();
+}
+
+static void color_checkbox_changed (
+    GtkToggleButton *toggle_button, gpointer user_data)
+{
+    ColourSetting *s = (ColourSetting *) user_data;
+
+    if (s == text_fg) {
+	update_colour_setting (&Config.text_fg, text_fg);
+	text_refresh ();
+    } else if (s == text_bg) {
+	update_colour_setting (&Config.text_bg, text_bg);
+	text_refresh ();
+    } else if (s == graphics_bg) {
+	update_colour_setting (&Config.graphics_bg, graphics_bg);
+	graphics_refresh ();
+    }
+}
+
 void do_config ()
 {
     GtkWidget *dialog;
     GtkWidget *dummy;
     GtkWidget *tabs;
     GtkWidget *text_font;
-    ColourSetting *text_fg;
-    ColourSetting *text_bg;
-    ColourSetting *graphics_bg;
     GtkWidget *graphics_tab;
     GtkWidget *colour_tab;
-    GtkWidget *constant_height;
-    GtkWidget *horizontal_split;
+    GtkWidget *fit_to_window;
     GtkWidget *red_gamma;
     GtkWidget *green_gamma;
     GtkWidget *blue_gamma;
     GtkWidget *animate_images;
     GtkWidget *animation_speed;
     GtkWidget *image_filter;
+    GtkWidget *position_combo;
+    GtkWidget *scale_combo;
+    GtkWidget *box;
+    GtkWidget *label;
+    GtkWidget *widget;
+    GtkWidget *scale_box;
     gint filter_idx;
     gint i;
+    gchar *saved_font = NULL;
+
+    Configuration saved_config = Config;
+    saved_font = Config.text_font ? g_strdup (Config.text_font) : NULL;
+    int saved_split = gtk_paned_get_position (GTK_PANED (Gui.partition));
+
+    gchar *saved_text_fg = Config.text_fg ? g_strdup (Config.text_fg) : NULL;
+    gchar *saved_text_bg = Config.text_bg ? g_strdup (Config.text_bg) : NULL;
+    gchar *saved_graphics_bg =
+	Config.graphics_bg ? g_strdup (Config.graphics_bg) : NULL;
 
     /*
      * Some settings, such as the partition, may have changed since they were
@@ -631,7 +835,7 @@ void do_config ()
      * restore the old values.
      */
     write_config_file ();
-    
+
     dialog = gtk_dialog_new_with_buttons (
 	"Preferences",
 	GTK_WINDOW (Gui.main_window),
@@ -641,6 +845,8 @@ void do_config ()
 	"_Cancel",
 	GTK_RESPONSE_REJECT,
 	NULL);
+
+    gtk_window_set_resizable (GTK_WINDOW (dialog), FALSE);
 
     gtk_window_set_default_size (GTK_WINDOW (dialog), 400, 400);
 
@@ -663,173 +869,216 @@ void do_config ()
 
     /* Text and colour settings */
 
-    text_font = add_font_button (colour_tab, "Text font:", "Select text font");
-    
-    if (!Config.text_font)
-    {
-	PangoFontDescription *font_desc;
-	gchar *font_name;
-	GtkStyleContext *context;
-
-	context = gtk_widget_get_style_context (Gui.text_view);
-	gtk_style_context_get (
-	    context, GTK_STATE_FLAG_NORMAL, "font", &font_desc, NULL);
-
-	font_name = pango_font_description_to_string (font_desc);
-	gtk_font_chooser_set_font (GTK_FONT_CHOOSER (text_font), font_name);
-
-	pango_font_description_free (font_desc);
-	g_free (font_name);
-    } else {
+    text_font = add_font_button (
+	colour_tab, "_Text font:", "Select Text Font");
+    if (Config.text_font)
 	gtk_font_chooser_set_font (
-	GTK_FONT_CHOOSER (text_font), Config.text_font);
-    }
-    
+	    GTK_FONT_CHOOSER (text_font), Config.text_font);
+    g_signal_connect (text_font, "font-set",
+	G_CALLBACK (font_changed), NULL);
+
+    dummy = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
+    gtk_box_pack_start (GTK_BOX (colour_tab), dummy, FALSE, FALSE, 8);
+
+    box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
+    gtk_box_pack_start (GTK_BOX (colour_tab), box, FALSE, FALSE, 0);
+
+    label = gtk_label_new_with_mnemonic ("Text _margins:");
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+    gtk_widget_set_size_request (label, 120, -1);
+    gtk_box_pack_start (GTK_BOX (box), label, FALSE, FALSE, 0);
+
+    widget = gtk_spin_button_new_with_range (0, 100, 1);
+    gtk_widget_set_size_request (widget, MIN_WINDOW_HEIGHT, -1);
+    gtk_spin_button_set_value (GTK_SPIN_BUTTON (widget), Config.text_margin);
+    gtk_box_pack_start (GTK_BOX (box), widget, TRUE, TRUE, 0);
+    gtk_label_set_mnemonic_widget (GTK_LABEL (label), widget);
+    g_signal_connect (widget, "value-changed",
+	G_CALLBACK (spin_changed_int), &Config.text_margin);
+    gtk_box_pack_start (GTK_BOX(box), 
+	add_reset_button (widget, 20.0), FALSE, FALSE, 0);
+
+    box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 5);
+    gtk_box_pack_start (GTK_BOX (colour_tab), box, FALSE, FALSE, 0);
+
+    label = gtk_label_new_with_mnemonic ("Line _spacing:");
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+    gtk_widget_set_size_request (label, 120, -1);
+    gtk_box_pack_start (GTK_BOX (box), label, FALSE, FALSE, 0);
+
+    widget = gtk_spin_button_new_with_range (0.0, 5.0, 0.5);
+    gtk_widget_set_size_request (widget, MIN_WINDOW_HEIGHT, -1);
+    gtk_spin_button_set_value (GTK_SPIN_BUTTON (widget), Config.text_leading);
+    gtk_box_pack_start (GTK_BOX (box), widget, TRUE, TRUE, 0);
+    gtk_label_set_mnemonic_widget (GTK_LABEL (label), widget);
+    g_signal_connect (widget, "value-changed",
+	G_CALLBACK (spin_changed_float), &Config.text_leading);
+    gtk_box_pack_start (GTK_BOX(box), 
+	add_reset_button (widget, 1.0), FALSE, FALSE, 0);
+
+    dummy = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
+    gtk_box_pack_start (GTK_BOX (colour_tab), dummy, FALSE, FALSE, 8);
+
     text_fg = add_colour_setting (
-	colour_tab, "Override text foreground colour",
-	"Select text coreground colour", Config.text_fg);
+	colour_tab, "Override text _foreground colour",
+	"Select text foreground colour", Config.text_fg);
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (text_fg->checkbox),
+	Config.text_fg != NULL);
+    g_signal_connect (text_fg->button, "color-set",
+	G_CALLBACK (color_changed), &Config.text_fg);
+    g_signal_connect (text_fg->checkbox, "toggled",
+	G_CALLBACK (color_checkbox_changed), text_fg);
+    if (saved_text_fg) Config.text_fg = g_strdup (saved_text_fg);
+
     text_bg = add_colour_setting (
-	colour_tab, "Override text background colour",
+	colour_tab, "Override text _background colour",
 	"Select text background colour", Config.text_bg);
+    gtk_toggle_button_set_active (
+	GTK_TOGGLE_BUTTON (text_bg->checkbox), Config.text_bg != NULL);
+    g_signal_connect (text_bg->button, "color-set",
+	G_CALLBACK (color_changed), &Config.text_bg);
+    g_signal_connect (text_bg->checkbox, "toggled",
+	G_CALLBACK (color_checkbox_changed), text_bg);
+    if (saved_text_bg) Config.text_bg = g_strdup(saved_text_bg);
+
     graphics_bg = add_colour_setting (
-	colour_tab, "Override picture background colour",
+	colour_tab, "Override picture back_ground colour",
 	"Select picture background colour", Config.graphics_bg);
+    gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON (graphics_bg->checkbox),
+	Config.graphics_bg != NULL);
+    g_signal_connect (graphics_bg->button, "color-set",
+	G_CALLBACK (color_changed), &Config.graphics_bg);
+    if (saved_graphics_bg) Config.graphics_bg = g_strdup(saved_graphics_bg);
 
     /* Picture settings */
 
-    constant_height = gtk_check_button_new_with_label (
-	"Scale image to constant height");
-    gtk_toggle_button_set_active (
-	GTK_TOGGLE_BUTTON (constant_height), Config.image_constant_height);
-    gtk_box_pack_start (
-	GTK_BOX (graphics_tab), constant_height, TRUE, TRUE, 0);
-
-    g_signal_connect (
-	G_OBJECT (constant_height), "toggled",
-	G_CALLBACK (toggle_constant_height), NULL);
-
-    image_scale_label = gtk_label_new (NULL);
-    gtk_label_set_xalign (GTK_LABEL (image_scale_label), 0.0);
-    gtk_label_set_yalign (GTK_LABEL (image_scale_label), 0.5);
-    gtk_box_pack_start (GTK_BOX (graphics_tab),
-	image_scale_label, TRUE, TRUE, 0);
-
-    image_scale = gtk_scale_new (GTK_ORIENTATION_HORIZONTAL, NULL);
-    gtk_scale_set_value_pos (GTK_SCALE (image_scale), GTK_POS_RIGHT);
-    gtk_box_pack_start (GTK_BOX (graphics_tab), image_scale, TRUE, TRUE, 0);
-
-    hSigScaleChanged = g_signal_connect (
-	G_OBJECT (image_scale), "value-changed",
-	G_CALLBACK (change_image_scale), constant_height);
-    
-    tmp_image_scale = Config.image_scale;
-    tmp_image_height = Config.image_height;
-    
-    toggle_constant_height (GTK_TOGGLE_BUTTON (constant_height), NULL);
-
-    dummy = gtk_label_new ("Interpolation mode:");
-    gtk_label_set_xalign (GTK_LABEL (dummy), 0.0);
-    gtk_label_set_yalign (GTK_LABEL (dummy), 0.5);
-    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, TRUE, TRUE, 0);
-
-    image_filter = gtk_combo_box_text_new ();
-    gtk_box_pack_start (GTK_BOX (graphics_tab), image_filter, TRUE, TRUE, 0);
-
-    for (i = 0; i < G_N_ELEMENTS (imageFilters); i++)
-    {
-	gtk_combo_box_text_append_text (
-	    GTK_COMBO_BOX_TEXT (image_filter), imageFilters[i].description);
+    const gchar *items[G_N_ELEMENTS (imageFilters)];
+    for (i = 0; i < G_N_ELEMENTS (imageFilters); i++) {
+	items[i] = imageFilters[i].description;
     }
-
-    gtk_combo_box_set_active (
-	GTK_COMBO_BOX (image_filter),
+    widget = add_combo_box (graphics_tab, "_Interpolation:",
+	items, G_N_ELEMENTS (imageFilters),
 	get_interp_type_index (Config.image_filter));
+    g_signal_connect (G_OBJECT (widget), "changed",
+	G_CALLBACK (on_filter_changed), NULL);
+
+    static const gchar *position_items[] = {
+	"Top",
+	"Bottom",
+	"Left",
+	"Right",
+	"Hidden"
+    };
+    position_combo = add_combo_box (graphics_tab, "Graphics _position:",
+	(const gchar **) position_items, G_N_ELEMENTS (position_items),
+	Config.graphics_position);
+    g_signal_connect (G_OBJECT (position_combo), "changed",
+	G_CALLBACK (on_position_changed), NULL);
+    gtk_combo_box_set_active (
+	GTK_COMBO_BOX (position_combo), Config.graphics_position);
+
+    static const gchar *scale_items[] = {
+	"Fit to window",
+	"Custom scale"
+    };
+    scale_combo = add_combo_box (graphics_tab, "_Scaling mode:",
+	(const gchar **) scale_items, G_N_ELEMENTS (scale_items),
+	Config.fit_to_window ? 0 : 1);
+    gtk_combo_box_set_active (
+	GTK_COMBO_BOX (scale_combo), Config.fit_to_window ? 0 : 1);
+
+    image_scale = add_scale (graphics_tab, "Scale _factor:", 0.1, 5.0, 0.1,
+	Config.image_scale, 2, 1.0);
+    g_signal_connect (image_scale, "value-changed",
+	G_CALLBACK (scale_changed), &Config.image_scale);
+    scale_box = gtk_widget_get_parent (image_scale);
+    gtk_widget_set_sensitive (scale_box, !Config.fit_to_window);
+    g_signal_connect (G_OBJECT (scale_combo), "changed",
+	G_CALLBACK (on_scale_combo_changed), scale_box);
 
     dummy = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
-    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, TRUE, TRUE, 8);
+    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, FALSE, FALSE, 8);
 
-    red_gamma = add_scale (
-	graphics_tab, "Red gamma:", 0.1, 5.0, 0.1, Config.red_gamma);
-    green_gamma = add_scale (
-	graphics_tab, "Green gamma:", 0.1, 5.0, 0.1, Config.green_gamma);
-    blue_gamma = add_scale (
-	graphics_tab, "Blue gamma:", 0.1, 5.0, 0.1, Config.blue_gamma);
+    /* Gamma settings */
+    red_gamma = add_scale (graphics_tab, "_Red gamma:", 0.1, 5.0, 0.1,
+	Config.red_gamma, 2, 1.0);
+    g_signal_connect (red_gamma, "value-changed",
+	G_CALLBACK (scale_changed), &Config.red_gamma);
+
+    green_gamma = add_scale (graphics_tab, "_Green gamma:", 0.1, 5.0, 0.1,
+	Config.green_gamma, 2, 1.0);
+    g_signal_connect (green_gamma, "value-changed",
+	G_CALLBACK(scale_changed), &Config.green_gamma);
+
+    blue_gamma = add_scale (graphics_tab, "_Blue gamma:", 0.1, 5.0, 0.1,
+	Config.blue_gamma, 2, 1.0);
+    g_signal_connect (blue_gamma, "value-changed",
+	G_CALLBACK (scale_changed), &Config.blue_gamma);
 
     dummy = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
-    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, TRUE, TRUE, 8);
+    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, FALSE, FALSE, 8);
 
-    animate_images = gtk_check_button_new_with_label ("Animate line drawing");
-    gtk_box_pack_start (GTK_BOX (graphics_tab), animate_images, TRUE, TRUE, 0);
-
-    animation_speed = add_scale (
-	graphics_tab, "Animation speed:", 1.0, 50.0, 1.0,
-	Config.animation_speed);
-    gtk_scale_set_digits (GTK_SCALE (animation_speed), 0);
-    
+    /* Animation settings */
+    animate_images =
+	gtk_check_button_new_with_mnemonic ("_Animate line drawing");
     gtk_toggle_button_set_active (
 	GTK_TOGGLE_BUTTON (animate_images), Config.animate_images);
-    gtk_widget_set_sensitive (
-	GTK_WIDGET (animation_speed), Config.animate_images);
-    
-    g_signal_connect (
-	G_OBJECT (animate_images), "toggled", G_CALLBACK (toggle_sensitivity),
-	animation_speed);
+    gtk_box_pack_start (GTK_BOX (graphics_tab), animate_images, TRUE, TRUE, 0);
+    g_signal_connect (animate_images, "toggled",
+	G_CALLBACK (toggle_changed), &Config.animate_images);
 
-    dummy = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
-    gtk_box_pack_start (GTK_BOX (graphics_tab), dummy, TRUE, TRUE, 8);
-
-    horizontal_split = gtk_check_button_new_with_mnemonic ("_Horizontal split");
-    gtk_toggle_button_set_active (
-        GTK_TOGGLE_BUTTON (horizontal_split), Config.horizontal_split);
-    gtk_box_pack_start (GTK_BOX (graphics_tab), horizontal_split, TRUE, TRUE, 0);
+    animation_speed = add_scale (
+	graphics_tab, "Animation sp_eed:", 1.0, 50.0, 1.0,
+	Config.animation_speed, 0, 10.0);
+    gtk_range_set_value (GTK_RANGE (animation_speed), Config.animation_speed);
+    g_signal_connect (animation_speed, "value-changed",
+	G_CALLBACK (scale_changed), &Config.animation_speed);
+    g_signal_connect (G_OBJECT (animation_speed), "format-value",
+	G_CALLBACK (format_animation_speed), NULL);
+    box = gtk_widget_get_parent (animation_speed);
+    gtk_widget_set_sensitive (box, Config.animate_images);
+    g_signal_connect (G_OBJECT (animate_images), "toggled",
+	G_CALLBACK (toggle_sensitivity), box);
 
     /* Run the dialog */
 
-    gtk_widget_show_all (gtk_dialog_get_content_area (GTK_DIALOG(dialog)));
+    gtk_widget_show_all (gtk_dialog_get_content_area (GTK_DIALOG (dialog)));
 
     if (gtk_dialog_run (GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
     {
 	g_free (Config.text_font);
-	Config.text_font = gtk_font_chooser_get_font (
-	    GTK_FONT_CHOOSER (text_font));
+	Config.text_font = g_strdup(
+	    gtk_font_chooser_get_font (GTK_FONT_CHOOSER(text_font)));
 
-	update_colour_setting (&(Config.text_fg), text_fg);
-	update_colour_setting (&(Config.text_bg), text_bg);
-	update_colour_setting (&(Config.graphics_bg), graphics_bg);
-	
-	Config.image_constant_height =
-	    gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (constant_height));
-	Config.image_scale = tmp_image_scale;
-	Config.image_height = tmp_image_height;
-	Config.red_gamma = gtk_range_get_value (GTK_RANGE (red_gamma));
-	Config.green_gamma = gtk_range_get_value (GTK_RANGE (green_gamma));
-	Config.blue_gamma = gtk_range_get_value (GTK_RANGE (blue_gamma));
-
-	Config.animate_images =
-	    gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (animate_images));
-	Config.animation_speed =
-	    (gint) gtk_range_get_value (GTK_RANGE (animation_speed));
-
-	filter_idx = gtk_combo_box_get_active (GTK_COMBO_BOX (image_filter));
-	if (filter_idx != -1)
-	    Config.image_filter = imageFilters[filter_idx].interp_type;
-	else
-	    Config.image_filter = GDK_INTERP_BILINEAR;
-	
-	Config.horizontal_split =
-	    gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (horizontal_split));
+	update_colour_setting (&Config.text_fg, text_fg);
+	update_colour_setting (&Config.text_bg, text_bg);
+	update_colour_setting (&Config.graphics_bg, graphics_bg);
 
 	write_config_file ();
+    }
+    else
+    {
+	Config = saved_config;
+	if (saved_font && g_utf8_validate (saved_font, -1, NULL)) {
+	    Config.text_font = g_strdup (saved_font);
+	    gtk_font_chooser_set_font (
+		GTK_FONT_CHOOSER (text_font), saved_font);
+	}
 
 	/* Apply settings */
 
 	text_refresh ();
 	graphics_refresh ();
 	gui_refresh ();
+	gtk_paned_set_position (GTK_PANED (Gui.partition), saved_split);
     }
-    
+
     gtk_widget_destroy (dialog);
     g_free (text_fg);
     g_free (text_bg);
     g_free (graphics_bg);
+    g_free (saved_font);
+    g_free (saved_text_fg);
+    g_free (saved_text_bg);
+    g_free (saved_graphics_bg);
 }

--- a/Gtk/config.h
+++ b/Gtk/config.h
@@ -54,27 +54,6 @@
 
 #define MAX_INSTRUCTIONS 20
 
-/*
- * We insert "dummy" spaces to make sure that the editable region is never
- * empty, otherwise GTK+ will remove it completely. To keep this space from
- * showing, we can use the "invisible" attribute.
- *
- * Before GTK+ 2.7.3 (I think), there would be a warning that this attribute is
- * not yet supported, but even with GTK+ 2.6.2 it worked well enough for this
- * purpose. If it doesn't work for you, or the warning message bothers you, you
- * can disable the use of it here.
- */
-
-#define USE_INVISIBLE_TEXT
-
-/*
- * GTK+ 2.6.8 still doesn't have any sensible way of changing the cursor
- * colour, and GtkTextView will use black by default no matter what the current
- * background colour is. Define this to use an ugly hack which seems to work.
- */
-
-#define USE_CURSOR_COLOUR_HACK
-
 typedef struct
 {
     gint window_width;
@@ -82,20 +61,21 @@ typedef struct
     gint window_split;
 
     gchar *text_font;
+    gint text_margin;
+    gdouble text_leading;
     gchar *text_fg;
     gchar *text_bg;
+    gchar *graphics_bg;
 
-    gboolean image_constant_height;
-    gdouble image_scale;
-    gint image_height;
     gint image_filter;     /* Should really be GdkInterpType, not gint */
+    gint graphics_position;
+    gboolean fit_to_window;
+    gdouble image_scale;
     gdouble red_gamma;
     gdouble green_gamma;
     gdouble blue_gamma;
-    gchar *graphics_bg;
     gboolean animate_images;
     gint animation_speed;
-    gboolean horizontal_split;
 } Configuration;
 
 extern Configuration Config;

--- a/Gtk/main.c
+++ b/Gtk/main.c
@@ -183,7 +183,7 @@ void do_about ()
 	"Dieter Baron and Andreas Scherrer.",
 
 	"comments",
-	"GTK 3.24 interface v2.0 by thr <r@sledinmay.com> ported from\n"
+	"GTK 3.24 interface v2.1 by thr <r@sledinmay.com> based on\n"
 	"GTK+ 2.6 interface v1.3 by Torbj\303\266rn Andersson <d91tan@Update.UU.SE>",
 	
 	"license",

--- a/Gtk/util.c
+++ b/Gtk/util.c
@@ -55,14 +55,28 @@ L9BOOL os_get_game_file(char *NewName, int Size)
     return TRUE;
 }
 
-void os_set_filenumber(char *NewName, int Size, int n)
+void os_set_filenumber (char *NewName, int Size, int n)
 {
-    char *fname;
+    char *fname, *ext;
     int i;
 
     fname = strrchr (NewName, '/');
     if (fname == NULL)
 	fname = NewName;
+
+    ext = strrchr (fname, '.');
+    if (ext != NULL) {
+	if ((ext[1] == 'l' || ext[1] == 'L') &&
+	    (isdigit (ext[2]) || ext[2] == '9') && ext[3] == '\0') {
+	    char lcase = ext[1];
+	    if (n == 1) {
+		sprintf (ext, ".%c9", lcase);
+	    } else {
+		sprintf (ext, ".%c%d", lcase, n);
+	    }
+	    return;
+	}
+    }
 
     /* Assume that the number is one digit only. */
     for (i = strlen(fname) - 1; i >= 0; i--) {
@@ -135,7 +149,7 @@ gchar *file_selector (gboolean save, gchar *name, const gchar **filters,
 		    gtk_file_filter_add_pattern (filter, "*.DAT");
 		else if (g_str_has_suffix (*pattern, ".l9"))
 		    gtk_file_filter_add_pattern (filter, "*.L9");
-                else if (g_str_has_suffix (*pattern, ".sna"))
+		else if (g_str_has_suffix (*pattern, ".sna"))
 		    gtk_file_filter_add_pattern (filter, "*.SNA");
 		pattern++;
 	    }


### PR DESCRIPTION
This needed some freshening up to keep up with the modern expectations. There are quite a few enhancements.

Highlights:

Typography and readability have been improved, and text margins and leading are now adjustable. GTK can render text nicely nowadays, so it should now look better than Gargoyle stable, and on-par with Gargoyle master branch.

A much-needed "fit graphics to viewport" option was added, because manually scaling the picture each time you resize the game window feels rather awkward in this day and age.

Horizontal split option allowed placing the graphics to the left side of text only. This seemed rather arbitrary in hindsight, so now there's proper choice, and graphics can be positioned to either side, below the textbox, or even wholly disabled.

Preferences window was redesigned and modernised. All options now have realtime preview, reset buttons when appropriate, and keyboard shortcuts.
![YxobHTGv3G](https://github.com/user-attachments/assets/9752f213-ad24-4b99-b62a-ee1f1d0c7b96)

Also fixed a couple old bugs.

And more, see NEWS for a complete changelog.