### PR TITLE
GTK: side-panels for Erik on Spectrum

### DIFF
--- a/Gtk/NEWS
+++ b/Gtk/NEWS
@@ -1,3 +1,15 @@
+2025-12-XX - 2.2 (The "Golden Dragon" release.)
+
+Bugfixes
+
+- Fixed a text buffer iterator issue that could very occasionally
+  cause an unintended insertion of a padding space.
+
+Other changes
+
+- Added support for the original side panels that were featured
+  exclusively in the ZX Spectrum version of Erik the Viking.
+
 2025-03-XX - 2.1 (The "Diamonds for eyes" release.)
 
 Bugfixes

--- a/Gtk/main.c
+++ b/Gtk/main.c
@@ -183,7 +183,7 @@ void do_about ()
 	"Dieter Baron and Andreas Scherrer.",
 
 	"comments",
-	"GTK 3.24 interface v2.1 by thr <r@sledinmay.com> based on\n"
+	"GTK 3.24 interface v2.2 by thr <r@sledinmay.com> based on\n"
 	"GTK+ 2.6 interface v1.3 by Torbj\303\266rn Andersson <d91tan@Update.UU.SE>",
 	
 	"license",

--- a/Gtk/text.c
+++ b/Gtk/text.c
@@ -686,6 +686,7 @@ void scroll_text_buffer (gboolean force)
 	gtk_text_buffer_move_mark (Gui.text_buffer, inputMark, &iter_end);
     }
 
+    gtk_text_buffer_get_end_iter (Gui.text_buffer, &iter);
     gtk_text_buffer_insert_with_tags_by_name (
 	Gui.text_buffer, &iter, " ", -1, "level9-input-padding", NULL);
     gtk_text_buffer_get_iter_at_mark (


### PR DESCRIPTION
Always best to fix your own problems, so here's the side-panels feature for Erik the Viking on ZX Spectrum. I'd like to port this to Windows later, but it should be fine to close issue #31 whenever you fancy now.

This is more like a fix than a feature, because these panels are actually supposed to be there, and it's such an edge case that it doesn't warrant an extra option toggle, so it just works by default when this specific version of Erik is detected. Only the ZX Spectrum version is supported, because it's the only one containing the extra picture that's being drawn here.

Also fixed an unrelated rare issue with text buffer iterator.

<img width="944" height="863" alt="erikpanels" src="https://github.com/user-attachments/assets/b84718e3-6632-4162-8929-3a3e6e62c6c7" />
<img width="944" height="863" alt="erikpanels2" src="https://github.com/user-attachments/assets/bc1d91eb-b13e-4a80-8051-ba04ac7e912c" />
